### PR TITLE
Use dotted imports (for Python 3)

### DIFF
--- a/src/keys_server/PiWind/__init__.py
+++ b/src/keys_server/PiWind/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from utils import *
-from PiWindKeysLookup import *
+from .utils import *
+from .PiWindKeysLookup import *

--- a/src/keys_server/PiWind/utils/__init__.py
+++ b/src/keys_server/PiWind/utils/__init__.py
@@ -1,2 +1,2 @@
-from AreaPerilLookup import *
-from VulnerabilityLookup import *
+from .AreaPerilLookup import *
+from .VulnerabilityLookup import *


### PR DESCRIPTION
Use of dotted imports means the example runs cleanly on Python 3 (when https://github.com/OasisLMF/OasisLMF/issues/41 is also resolved)