### PR TITLE
Swap back package install order

### DIFF
--- a/docker/Dockerfile.piwind_worker
+++ b/docker/Dockerfile.piwind_worker
@@ -23,12 +23,11 @@ ENTRYPOINT ./startup.sh
 COPY $ods_package ./
 COPY $oasislmf_package ./
 
-# Install MDK from package file (Optional)
-RUN test -z "$oasislmf_package" || pip install $oasislmf_package --force-reinstall
-
 # Install ods_tools from package file (Optional)
 RUN test -z "$ods_package" || pip install $ods_package --force-reinstall
 
+# Install MDK from package file (Optional)
+RUN test -z "$oasislmf_package" || pip install $oasislmf_package --force-reinstall
 
 # install MDK from git branch (Optional)
 RUN if [ ! -z "$oasislmf_branch" ] ; then \


### PR DESCRIPTION
### fix numpy clash when building the piwind image 
Installing  `oasislmf` then  `ods_tools` can cause issues with the numpy package version 
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
oasislmf 1.27.0rc3 requires numpy<1.23,>=1.18, but you have numpy 1.24.0 which is incompatible.
numba 0.56.4 requires numpy<1.24,>=1.18, but you have numpy 1.24.0 which is incompatible.
Successfully installed chardet-5.1.0 numpy-1.24.0 ods-tools-2.3.2 pandas-1.5.2 python-dateutil-2.8.2 pytz-2022.7 six-1.16.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```