### PR TITLE
Feature/enable-gulmc-update-model-settings-for-hazard

### DIFF
--- a/meta-data/model_settings.json
+++ b/meta-data/model_settings.json
@@ -26,11 +26,12 @@
         ]
     },
     "correlation_settings": [
-      {"peril_correlation_group":  1, "correlation_value":  "0.7"},
-      {"peril_correlation_group":  2, "correlation_value":  "0.5"}
-    ],
-    "data_settings": {
-	"group_fields": ["PortNumber", "AccNumber", "LocNumber"]
-    },
+          {"peril_correlation_group":  1, "damage_correlation_value":  "0.7", "hazard_correlation_value":  "0.0"},
+          {"peril_correlation_group":  2, "damage_correlation_value":  "0.5", "hazard_correlation_value":  "0.0"}
+      ],
+      "data_settings": {
+          "damage_group_fields": ["PortNumber", "AccNumber", "LocNumber"],
+          "hazard_group_fields": ["PortNumber", "AccNumber", "LocNumber"]
+      },
     "model_default_samples" :10
 }

--- a/oasislmf.json
+++ b/oasislmf.json
@@ -8,7 +8,8 @@
     "oed_accounts_csv": "tests/inputs/SourceAccOEDPiWind.csv",
     "oed_info_csv": "tests/inputs/SourceReinsInfoOEDPiWind.csv",
     "oed_scope_csv": "tests/inputs/SourceReinsScopeOEDPiWind.csv",
-    "modelpy": true,
-    "gulpy": true,
+    "modelpy": false,
+    "gulpy": false,
+    "gulmc": true,
     "ktools_alloc_rule_gul": 1
 }


### PR DESCRIPTION
In this PR:
 - we enable `gulmc` by default (instead of `modelpy | gulpy`)
 - we update `model_settings.json` to comply with new schema introduced by PR https://github.com/OasisLMF/OasisLMF/pull/1181 in oasislmf repo, which introduces hazard correlation features.
