### PR TITLE
Pin PyYaml due to breakage with cython==3.0.0

### DIFF
--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -5,3 +5,4 @@ pathlib
 requests
 pandas 
 parametrize
+pyYaml==5.3.1


### PR DESCRIPTION
### Fix PiWind testing 
* Pin PyYaml due to breakage with cython==3.0.0