### PR TITLE
Enable PLA in analysis_settings

### DIFF
--- a/analysis_settings.json
+++ b/analysis_settings.json
@@ -6,6 +6,7 @@
     "model_supplier_id": "OasisLMF",
     "gul_threshold": 0,
     "gul_output": true,
+    "pla": true,
     "model_settings": {
         "event_set": "p",
         "event_occurrence_id": "lt"

--- a/tests/ci/ALL_output_analysis_settings.json
+++ b/tests/ci/ALL_output_analysis_settings.json
@@ -5,6 +5,7 @@
     "model_name_id": "PiWind",
     "model_supplier_id": "OasisLMF",
     "number_of_samples": 1,
+    "pla": true,
     "gul_threshold": 0,
     "gul_output": true,
     "model_settings": {

--- a/tests/ci/FM_analysis_settings.json
+++ b/tests/ci/FM_analysis_settings.json
@@ -3,6 +3,7 @@
     "source_tag": "piwind",
     "analysis_tag": "FM_integration_test",
     "exposure_location": "L:",
+    "pla": true,
     "gul_output": true,
     "gul_summaries": [
         {

--- a/tests/ci/GUL_analysis_settings.json
+++ b/tests/ci/GUL_analysis_settings.json
@@ -3,6 +3,7 @@
     "source_tag": "piwind",
     "analysis_tag": "GUL_integration_test",
     "exposure_location": "L:",
+    "pla": true,
     "gul_output": true,
     "gul_summaries": [
         {

--- a/tests/ci/ORD_csv_analysis_settings.json
+++ b/tests/ci/ORD_csv_analysis_settings.json
@@ -5,6 +5,7 @@
     "model_name_id": "PiWind",
     "model_supplier_id": "OasisLMF",
     "number_of_samples": 10,
+    "pla": true,
     "gul_threshold": 0,
     "gul_output": true,
     "model_settings": {

--- a/tests/ci/ORD_parquet_analysis_settings.json
+++ b/tests/ci/ORD_parquet_analysis_settings.json
@@ -5,6 +5,7 @@
     "model_name_id": "PiWind",
     "model_supplier_id": "OasisLMF",
     "number_of_samples": 10,
+    "pla": true,
     "gul_threshold": 0,
     "gul_output": true,
     "model_settings": {

--- a/tests/ci/RI_analysis_settings.json
+++ b/tests/ci/RI_analysis_settings.json
@@ -3,6 +3,7 @@
     "source_tag": "piwind",
     "analysis_tag": "RI_integration_test",
     "exposure_location": "L:",
+    "pla": true,
     "gul_output": true,
     "gul_summaries": [
         {


### PR DESCRIPTION
### Enable PLA in analysis Settings 

In https://github.com/OasisLMF/OasisPiWind/pull/141 the expected results files were updated to execute with PLA enabled. 

In  https://github.com/OasisLMF/OasisLMF/pull/1369 PLA can now be explicitly enabled/disabled in the `analysis_settings.json` using the boolean option.
```
"pla": true,
``` 

If no value is given, `PLA == False`, updated the Piwind analysis settings examples to switch back on PLA so piwind passes CI 