### PR TITLE
Pin docker[ssh] to 6.1.3

### DIFF
--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -6,3 +6,4 @@ requests
 pandas 
 parametrize
 pyYaml==5.3.1
+docker[ssh]==6.1.3


### PR DESCRIPTION
Piwind Intergration tests are failing with the following, pip the python test `requirements.in` to the last known good version

```
environment = {'SELENIUM_JAR_PATH': '/usr/share/java/selenium-server.jar', 'CONDA': '/usr/share/miniconda', 'GITHUB_WORKSPACE': '/ho...bin/pytest', 'PYTEST_CURRENT_TEST': 'tests/test_piwind_integration.py::TestOasisModel::test_for_missing_files (setup)'}
version = None, context = None, tls_version = None

    def docker_client(environment, version=None, context=None, tls_version=None):
        """
        Returns a docker-py client configured using environment variables
        according to the same logic as the official Docker client.
        """
        try:
>           kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
E           TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
```