### PR TITLE
Droping py3.8 check

### DIFF
--- a/.github/workflows/run_mdk.yml
+++ b/.github/workflows/run_mdk.yml
@@ -77,7 +77,7 @@ jobs:
     needs: ods_tools
     strategy:
       matrix:
-        py-version: ["3.8", "3.9", "3.10"]
+        py-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Github context
         run:   echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
Run fails due to issue with Py3.8 and `fsspec-2025.3.1`  

Python 3.8 reached its end of life as of October 7, 2024 so dropping this test in favour of `py3.11`